### PR TITLE
Capture service versions in the framework, not in tests.

### DIFF
--- a/terraform/krill-e2e-test/tests/util/docker.py
+++ b/terraform/krill-e2e-test/tests/util/docker.py
@@ -12,6 +12,15 @@ from tests.util.collections import isiterable
 from tests.util.pytest import isfailed
 
 
+# Map of service_name to shell command to obtain the version.
+version_cmds_by_service_name = {}
+versions_by_service_name = {}
+
+
+def register_version_cmd(service_name, cmd):
+    version_cmds_by_service_name[service_name] = cmd
+
+
 def get_container_logs(docker_project, service_name, prefix=True,
     timestamps=True, since=None, until=None):
 
@@ -35,19 +44,48 @@ def run_command(docker_project, service_name, cmd):
 
 
 class ServiceManager:
-    def __init__(self, request):
+    def __init__(self, request, metadata):
         self.start_time = int(time())
         self.docker_project = None
         self.request = request
+        self.metadata = metadata
         self.service_names = []
         self.passed = False
 
     def start_services_with_dependencies(self, docker_project, service_names):
         self.docker_project = docker_project
         self.service_names = service_names if isiterable(service_names) else [service_names]
+
         logging.info(f'Starting Docker services {self.service_names}...')
         self.docker_project.up(service_names=self.service_names)
+
         logging.info(f'Active containers: {[c.name for c in self.docker_project.containers()]}')
+
+        for service_name in self.service_names:
+            self.capture_service_version(service_name)
+
+    def capture_service_version(self, service_name):
+        if service_name in versions_by_service_name:
+            # We've already captured the version of this service
+            return
+
+        if service_name not in version_cmds_by_service_name:
+            # We don't know how to capture the version of this service
+            return
+
+        version_cmd = version_cmds_by_service_name[service_name]
+
+        # Obtain the service version if not already obtained and if obtainable:
+        logging.info(f"Detecting version of service '{service_name}'' using command '{version_cmd}'..")
+        (exit_code, output) = run_command(self.docker_project, service_name, version_cmd)
+        output = output.decode('utf-8').strip()
+        logging.info(f"Command exit code={exit_code}, output={output}")
+
+        # Remember this service version, and add a row to the pytest-html
+        # metadata table at the top of the report showing the version string
+        # for this relying party.
+        versions_by_service_name[service_name] = output
+        self.metadata[f"{service_name} version"] = output
 
     def teardown(self):
         self.end_time = int(time())
@@ -103,14 +141,14 @@ def docker_project():
 
 
 @pytest.fixture(scope="class")
-def class_service_manager(request):
-    mgr = ServiceManager(request)
+def class_service_manager(request, metadata):
+    mgr = ServiceManager(request, metadata)
     yield mgr
     mgr.teardown()
 
 
 @pytest.fixture(scope="function")
-def function_service_manager(request):
-    mgr = ServiceManager(request)
+def function_service_manager(request, metadata):
+    mgr = ServiceManager(request, metadata)
     yield mgr
     mgr.teardown()

--- a/terraform/krill-e2e-test/tests/util/krill.py
+++ b/terraform/krill-e2e-test/tests/util/krill.py
@@ -5,6 +5,10 @@ import pytest
 
 from contextlib import contextmanager
 from krill_api.rest import ApiException
+from tests.util.docker import register_version_cmd
+
+
+register_version_cmd('krill', 'krill --version')
 
 
 class KrillUnknownPublisherException(Exception):

--- a/terraform/krill-e2e-test/tests/util/relyingparties.py
+++ b/terraform/krill-e2e-test/tests/util/relyingparties.py
@@ -1,6 +1,6 @@
 import requests
 
-from tests.util.docker import get_docker_host_fqdn
+from tests.util.docker import get_docker_host_fqdn, register_version_cmd
 
 
 class RelyingParty:
@@ -22,7 +22,7 @@ class RelyingParty:
         # Routinator and RPKI Validator 3 expose HTTP APIs and only Routinator
         # makes it easy to get the version via that API. So instead issue
         # commands in the RP Docker containers.
-        self.version_cmd = version_cmd
+        register_version_cmd(self.name, version_cmd)
 
     def __str__(self):
         return self.name
@@ -34,7 +34,6 @@ class RelyingParty:
 class RPKIValidator3(RelyingParty):
     def __init__(self, name, rtr_port, rtr_timeout_seconds, version_cmd):
         super().__init__(name, rtr_port, rtr_timeout_seconds, version_cmd)
-
 
     def is_ready(self):
         # Check to see if the RIPE NCC RPKI validator has processed the TAL yet.


### PR DESCRIPTION
Also capture the version of Krill.